### PR TITLE
Avoid GCE builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: smalltalk
 sudo: true
+group: legacy # Avoid GCE builds for now
 
 smalltalk:
 #  - Squeak-trunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
   include:
     # Bash tests
     - language: generic
+      sudo: false
       script:
         - bash tests/run_tests.sh
         - bash tests/helpers_tests.sh


### PR DESCRIPTION
I haven't tested smalltalkCI on GCE yet, because there is [this bug](https://github.com/travis-ci/travis-ci/issues/5262).

`group: legacy` will force a Blue Box (legacy) build:
https://gist.github.com/meatballhat/d0c8aab9e3bd8a8bcacd#file-01-matrix-include-travis-yml-L18-L19
